### PR TITLE
Attempt to check whether output stream is a TTY before using escapes

### DIFF
--- a/console-colors.c
+++ b/console-colors.c
@@ -27,6 +27,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "console-colors.h"
@@ -147,7 +149,7 @@ int cc_fprintf(cc_color_t color, FILE* stream, const char* format, ...) {
     va_start(ap, format);
     int result = -EINVAL;
 
-    if (stream != stdout && stream != stderr) {
+    if (!isatty(fileno(stream)) || (stream != stdout && stream != stderr)) {
         result = Write(stream, format, ap);
         goto finish;
     }


### PR DESCRIPTION
This doesn't check full termcap attributes, but it checks with isatty(3).

Also, this follows the current #ifdef _WIN32 #else assume Unix #endif
pattern; this will need to be changed if more platforms are added.
